### PR TITLE
create Fernet lazily, in case the KOMBU_FERNET_KEY is programmatically set

### DIFF
--- a/kombu_fernet/serializers/__init__.py
+++ b/kombu_fernet/serializers/__init__.py
@@ -2,19 +2,25 @@
 from __future__ import unicode_literals, absolute_import
 
 import os
-from cryptography.fernet import Fernet, InvalidToken
+from cryptography.fernet import Fernet
 
-fernet = Fernet(os.environ['KOMBU_FERNET_KEY'])
+
+def lazy_fernet():
+    if not hasattr(lazy_fernet, 'fernet'):
+        lazy_fernet.fernet = Fernet(os.environ['KOMBU_FERNET_KEY'])
+    return lazy_fernet.fernet
+
 
 def fernet_encode(func):
     def inner(message):
-        return fernet.encrypt(func(message))
+        return lazy_fernet().encrypt(func(message))
     return inner
+
 
 def fernet_decode(func):
     def inner(encoded_message):
         if isinstance(encoded_message, unicode):
             encoded_message = encoded_message.encode('utf-8')
-        message = fernet.decrypt(encoded_message)
+        message = lazy_fernet().decrypt(encoded_message)
         return func(message)
     return inner

--- a/kombu_fernet/serializers/pickle.py
+++ b/kombu_fernet/serializers/pickle.py
@@ -5,6 +5,7 @@ from kombu.serialization import pickle, pickle_protocol, unpickle
 
 from . import fernet_encode, fernet_decode
 
+
 def pickle_dumps(obj, dumper=pickle.dumps):
     return dumper(obj, protocol=pickle_protocol)
 


### PR DESCRIPTION
The reason I need this is, in tests, I want to be able to programmatically change out the environ, and reload the module to simulate different things.

Having Fernet read the key immediately just crashes the tests.