### PR TITLE
Bump cryptography 3.4.8 -> 48.0.1 (GHSA-537c-gmf6-5ccf)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 kombu==4.6.11
-cryptography==3.4.8
+cryptography==48.0.1
 six==1.10.0


### PR DESCRIPTION
## What

Bump `cryptography` from `3.4.8` to `48.0.1` in `requirements.txt`.

## Why

Closes Dependabot alert [#13](https://github.com/heroku/kombu-fernet-serializers/security/dependabot/13) — **GHSA-537c-gmf6-5ccf** (High): "Vulnerable OpenSSL included in cryptography wheels." Vulnerable range is `>= 0.5.0, < 48.0.1`; `48.0.1` is the first patched version.

Pinned to the minimal patched version (`48.0.1`) rather than latest (`49.0.0`) to keep the jump as small as possible. `cryptography>=2.0.2` in `setup.py` already permits this; no change needed there.

Note: the open Snyk PRs (#34–#41) top out at `46.0.5`, which is **below** the `48.0.1` patch floor, so none of them actually close this alert. This direct bump supersedes them.

## Risk / verification

This package only consumes `cryptography`'s `Fernet` API, which has been stable across these versions. CI (test suite exercising the serializers) is the verification.

## Base branch

Targets `edit-team/codeowners-notify` (PR #42) rather than `main`, because the working CI workflow lives on that branch — branching off `main` would hit the old broken workflow. Rebase onto `main` once #42 merges.

---
SOC2: `USER STORY` label set so Git2Gus autocreates the GUS work item.
