### PR TITLE
Bump cryptography to 48.0.1 to resolve high-severity Dependabot alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 kombu==4.6.11
-cryptography==3.4.8
+cryptography==48.0.1
 six==1.10.0


### PR DESCRIPTION
## Summary

Bumps `cryptography` from `3.4.8` to `48.0.1` in `requirements.txt`, resolving **all four** open high-severity Dependabot alerts:

| Alert | Summary | Vulnerable range | First patched |
|---|---|---|---|
| [#13](https://github.com/heroku/kombu-fernet-serializers/security/dependabot/13) | Vulnerable OpenSSL included in cryptography wheels | `>= 0.5.0, < 48.0.1` | 48.0.1 |
| [#10](https://github.com/heroku/kombu-fernet-serializers/security/dependabot/10) | Subgroup attack due to missing subgroup validation for SECT curves | `<= 46.0.4` | 46.0.5 |
| [#8](https://github.com/heroku/kombu-fernet-serializers/security/dependabot/8) | Bleichenbacher timing oracle attack | `< 42.0.0` | 42.0.0 |
| [#2](https://github.com/heroku/kombu-fernet-serializers/security/dependabot/2) | Vulnerable OpenSSL included in cryptography wheels | `>= 0.8.1, < 39.0.1` | 39.0.1 |

`48.0.1` is the highest first-patched version across the alerts, so a single bump clears all of them.

## Compatibility

- `cryptography 48.0.1` supports Python 3.10 and 3.11 — the project's only supported targets (`python_requires=">=3.10"`).
- `setup.py` already declares `cryptography>=2.0.2`, so no constraint change is needed there.

## Testing

- `pip install -r requirements.txt -r requirements.test.txt` installs cleanly with cryptography 48.0.1.
- Full test suite passes: `4 passed` (Python 3.10, pytest 9.0.3). Remaining warnings are pre-existing and unrelated to this change.